### PR TITLE
Fixed graphical issue with scrollbar auto appearing

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
             position: relative;
             bottom: 0;
             width: 80%;
-            height:96vh;
+            height:80vh;
             float:left;
             overflow-y:auto;
             border:solid;
@@ -63,10 +63,11 @@
             position: relative;
             bottom: 0;
             width: 20%;
-            height:96vh;
+            height:70vh;
             float:right;
             overflow-y:auto;
             text-align:center;
+
 
 
         }


### PR DESCRIPTION
There was an issue where the chatroom was displaying too large and forcing the scroll bar on the right to appear for no reason basically. This was being caused by the userlist div being pushed down by the header. Adjusted the size of the userlist div to fix this